### PR TITLE
Update app.json

### DIFF
--- a/APP_Source/Apps/azul_icedtea_web/app.json
+++ b/APP_Source/Apps/azul_icedtea_web/app.json
@@ -10,10 +10,11 @@
   "author": "The IGEL community",
   "vendor": "Azul",
   "rw_partition": {
-    "size": "small",
+    "size": "large",
     "flags": [
       "compressed",
-      "prefer_btrfs"
+      "prefer_btrfs",
+       "allow_execute"
     ]
   },
   "release": "",


### PR DESCRIPTION
Hi Ron, While creating a OpenWebStart recipe for an customer, I ran into the following issue. By default our RW partitions is mounted with the "no-execute" flag, so the downloaded Java programs where not able to start. Dev told me to add the "allow_execute" flag to my recipe. I asume icedtea web will have the same problem