### PR TITLE
Update iaiops recipe to 0.20.1 (fixes edition tags that were never published)

### DIFF
--- a/APP_Source/Apps/iaiops/README.md
+++ b/APP_Source/Apps/iaiops/README.md
@@ -32,7 +32,7 @@ lock down the endpoint (overrides the unit defaults):
 
 ```sh
 # /services_rw/iaiops/iaiops.env
-IAIOPS_IMAGE=ghcr.io/industrial-aiops/iaiops:0.12.0-building
+IAIOPS_IMAGE=ghcr.io/industrial-aiops/iaiops:0.20.1-building
 IAIOPS_MCP=building
 IAIOPS_MCP_TRANSPORT=sse
 IAIOPS_ALLOWLIST_ACCOUNTS=ops-agent

--- a/APP_Source/Apps/iaiops/app.json
+++ b/APP_Source/Apps/iaiops/app.json
@@ -19,5 +19,5 @@
   "summary": {
     "en": "Industrial-AIOps — governed, read-first OT diagnostics (Community)"
   },
-  "version": "0.12.0+1.0"
+  "version": "0.20.1+1.0"
 }

--- a/APP_Source/Apps/iaiops/data/changelogs/en
+++ b/APP_Source/Apps/iaiops/data/changelogs/en
@@ -1,3 +1,15 @@
+0.20.1+1.0
+
+- Track the current iaiops release: the image is now 0.20.1 (was 0.12.0).
+- FIX: the building/water edition examples pointed at 0.12.0 tags that were never
+  published — only factory, fab and process exist for 0.12.0. All five edition
+  tags exist for 0.20.1, so switching IAIOPS_IMAGE now works as documented.
+- Every MCP tool now carries the standard tool annotations (readOnlyHint /
+  destructiveHint), derived from the governance harness — a managed endpoint's
+  agent can tell a read from a plant write without parsing tool descriptions.
+- Audit now covers the CLI as well as the MCP server, so a write cannot bypass
+  the audit trail by using the other front-end.
+
 0.12.0+1.0
 
 - Initial community recipe: launches the iaiops 0.12.0 OCI image via Podman.

--- a/APP_Source/Apps/iaiops/input/all/etc/systemd/system/iaiops.service
+++ b/APP_Source/Apps/iaiops/input/all/etc/systemd/system/iaiops.service
@@ -11,12 +11,12 @@ Wants=network-online.target
 # Site configuration goes in /services_rw/iaiops/iaiops.env (optional; overrides
 # the defaults below). Typical keys — pick the edition/profile your site runs and
 # lock down who may reach the MCP endpoint:
-#   IAIOPS_IMAGE=ghcr.io/industrial-aiops/iaiops:0.12.0-building
+#   IAIOPS_IMAGE=ghcr.io/industrial-aiops/iaiops:0.20.1-building
 #   IAIOPS_MCP=building
 #   IAIOPS_MCP_TRANSPORT=sse
 #   IAIOPS_ALLOWLIST_ACCOUNTS=ops-agent
 #   IAIOPS_ALLOWLIST_IPS=10.0.0.0/24
-Environment=IAIOPS_IMAGE=ghcr.io/industrial-aiops/iaiops:0.12.0-factory
+Environment=IAIOPS_IMAGE=ghcr.io/industrial-aiops/iaiops:0.20.1-factory
 Environment=IAIOPS_MCP=factory
 Environment=IAIOPS_MCP_TRANSPORT=sse
 EnvironmentFile=-/services_rw/iaiops/iaiops.env


### PR DESCRIPTION
Follow-up to #520. The recipe was written on 2026-07-12 and merged on 2026-07-29; upstream `iaiops` moved from 0.12.0 to **0.20.1** in between.

## The part that is a real bug, not just staleness

Both the README and the systemd unit tell the operator how to switch edition:

```sh
IAIOPS_IMAGE=ghcr.io/industrial-aiops/iaiops:0.12.0-building
```

**That tag does not exist.** Checked against GHCR:

| version | factory | fab | process | building | water |
|---|---|---|---|---|---|
| 0.12.0 | ✓ | ✓ | ✓ | **404** | **404** |
| 0.20.1 | ✓ | ✓ | ✓ | ✓ | ✓ |

The 0.12.0 image set was published incompletely (a since-fixed race in our release workflow left several profile tags missing for 0.12.x–0.13.x). The default `factory` tag works, which is why this was not caught during review — but an operator following the documented example for a building-automation or water-utility endpoint would hit an image-pull failure.

All five edition tags exist for 0.20.1, so the documented switch now works.

## Changes

- `input/all/etc/systemd/system/iaiops.service` — default image → `0.20.1-factory`; the commented edition example → `0.20.1-building`
- `README.md` — same example
- `app.json` — `version` → `0.20.1+1.0`
- `data/changelogs/en` — new entry

No structural changes: the container hardening (read-only rootfs, all caps dropped, no-new-privileges), the `/services` + `/services_rw` layout, and the localhost-bound MCP endpoint are untouched.

## Worth knowing for a managed endpoint

Two upstream changes since 0.12.0 matter in the IGEL context:

- Every MCP tool now carries the standard `readOnlyHint` / `destructiveHint` annotations, derived from the governance harness rather than hand-written, so the agent on the endpoint can distinguish a read from a plant write without parsing descriptions — and a client can require confirmation on the destructive ones.
- Audit now covers the CLI as well as the MCP server. Previously a write issued via the CLI left no audit row; both front-ends are now governed at their own boundary and share one audit store.

Images are multi-arch (amd64/arm64) and cosign-signed.